### PR TITLE
Fixes DanielSnd/UniParticles3D#3 by using normal uniforms for the bui…

### DIFF
--- a/addons/UniParticles3D/uniparticle_include.gdshaderinc
+++ b/addons/UniParticles3D/uniparticle_include.gdshaderinc
@@ -6,11 +6,11 @@ uniform sampler2D albedo_texture : source_color, repeat_disable, filter_linear_m
 
 uniform sampler2D gradient_texture : source_color, hint_default_white, repeat_disable;
 
-instance uniform int billboard_mode = 0;
-instance uniform int align_to_velocity = 0;
-instance uniform int particles_anim_h_frames : hint_range(1, 128) = 1;
-instance uniform int particles_anim_v_frames : hint_range(1, 128) = 1;
-instance uniform vec4 tint_color:source_color = vec4(1.0);
+uniform int billboard_mode = 0;
+uniform int align_to_velocity = 0;
+uniform int particles_anim_h_frames : hint_range(1, 128) = 1;
+uniform int particles_anim_v_frames : hint_range(1, 128) = 1;
+uniform vec4 tint_color:source_color = vec4(1.0);
 
 vec3 hue_change(vec3 input_color, float shift_hue) {
 	vec3 color_hsv;


### PR DESCRIPTION
…lt-in materials


This removes the limit on the number of particles in web builds. 
(which is currently max 160 particles according to my tests = 16 particle systems of 10 particles in the whole level)


This is fixed by not using instance uniforms anymore for the "UniParticles built-in shader materials".

Note that the code to use instance uniforms is still there for "material overrides" since I want to be backwards compatible and it makes sense that the material isn't touched by the node if it is an override material (and can have different tint in different UniParticle nodes).